### PR TITLE
Add compatibility mode for Vertico

### DIFF
--- a/test/tests.el
+++ b/test/tests.el
@@ -89,3 +89,19 @@
        nil
        6) ; Point as in "/usr/s|/man"
       '("share/" . 5)))))
+
+;;; Vertico integration
+
+(ert-deftest vertico--all-completions-advice-test ()
+  (cl-flet ((f (apply-partially
+                #'hotfuzz--vertico--all-completions-advice
+                (lambda (&rest args) (cons (apply #'completion-all-completions args) nil)))))
+    ;; If hotfuzz was not tried or produced no matches: Do not set highlighting fn
+    (let ((completion-styles '(basic hotfuzz)))
+      (should (equal (f "x" '("x") nil 1) '(("x" . 0) . nil))))
+    (let ((completion-styles '(hotfuzz)))
+      (should (equal (f "y" '("x") nil 1) '(nil . nil)))
+      (cl-destructuring-bind (xs . hl) (f "x" '("x") nil 1)
+        ;; Highlighting should not yet have been applied
+        (should (equal-including-properties xs '(#("x" 0 1 (completion-sorted t)))))
+        (should-not (null hl))))))


### PR DESCRIPTION
This pull request adds a compatibility mode for the Vertico completion system that sets it up to lazily apply highlighting to Hotfuzz completions.

This is motivated by a desire to reach feature parity between Vertico and Selectrum, due to the potentiality of Selectrum being sunset, see minad/vertico#237.

Do you have any thoughts on this @minad? Advicing foreign functions in library code is something I would rather avoid, but here I think the utility outweighs the trouble of possible breakages caused by any future Vertico updates.

Also relevant to #2.