### PR TITLE
Explain how to use hotfuzz with Fido

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,15 @@ To use hotfuzz, add it to the `completion-styles` list:
 ```elisp
 (setq completion-styles '(hotfuzz))
 ```
+
+Or, if using
+[Fido](https://www.gnu.org/software/emacs/manual/html_node/emacs/Icomplete.html),
+add hotfuzz to the `completion-styles` list this way:
+
+```elisp
+(add-hook 'icomplete-minibuffer-setup-hook
+          (lambda () (setq-local completion-styles '(hotfuzz))))
+```
 or, if using [Selectrum], enable `hotfuzz-selectrum-mode`.
 
 **Note:** Highlighting of the matched characters is only applied to


### PR DESCRIPTION
This pull request adds instructions to the README for using hotfuzz with [Fido](https://www.gnu.org/software/emacs/manual/html_node/emacs/Icomplete.html).

The reason why these instructions are needed is that the `icomplete--fido-mode-setup` function in [icomplete.el](https://git.savannah.gnu.org/cgit/emacs.git/tree/lisp/icomplete.el) overrides the user's `completion-styles` list.

(Fussy's README includes [similar instructions](https://github.com/jojojames/fussy#icompletefido-integration).)